### PR TITLE
replace 'match' keyword with 'get' (in router). Critical for Rails 4

### DIFF
--- a/lib/elrte/router.rb
+++ b/lib/elrte/router.rb
@@ -14,7 +14,7 @@ module Elrte
     #   end
     #
     def apply(router)
-      router.send('match', {'elfinder' => 'elfinder#connector', :as => 'elfinder_connector'})
+      router.send('get', {'elfinder' => 'elfinder#connector', :as => 'elfinder_connector'})
       #p @application.namespaces.values
       #router.instance_exec(@application.namespaces.values) do |namespaces|
       #  namespaces.each do |namespace|


### PR DESCRIPTION
Hi. I'm currently updating one of my projects to run on Rails 4 and found myself unable to install `elrte`.
This is actually small thing. Related to this issue: rails/rails#5964

Command

```
bundle exec rails generate elrte:install
```

Can't be finished in rails 4.rc1

```
/Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:191:in `normalize_conditions!': You should not use the `match` method in your router without specifying an HTTP method. (RuntimeError)
If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"
  Do: get "controller#action"
    from /Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:67:in `initialize'
    from /Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:1430:in `new'
```

So I quickly fixed it. Although I didn't test it with rails 3, this change should not breake anything, as `get` keyword is supported by earlier Rails versions.
