### PR TITLE
Elfinder connector route. Rails 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirments
 Installation
 ------------
 
-Include gem into to your Gemfile
+Add this line to your Gemfile
 
      gem 'elrte'
 
@@ -24,16 +24,16 @@ Generate gem files
 
 Require javascript file (in application.js or may be in active_admin.js)
 
-    //= require elrte
+    //= require elrte/base
 
-Also if include jquery if you need
+Also include jquery if you need
 
     //= require jquery
     //= require jquery-ui
 
 Require stylesheet file (in application.css or may be in active_admin.css)
 
-    @import 'elrte';
+    @import 'elrte/base';
 
 Add class 'editor' to needed fields and you will see WYSIWYG elfinder editor instead of textareas
 

--- a/lib/elrte/router.rb
+++ b/lib/elrte/router.rb
@@ -14,7 +14,7 @@ module Elrte
     #   end
     #
     def apply(router)
-      router.send(:get, {'elfinder' => 'elfinder#connector', :as => 'elfinder_connector'})
+      router.send(:match, {'elfinder' => 'elfinder#connector', :as => 'elfinder_connector', :via => [:get, :post]})
     end
 
   end

--- a/lib/elrte/router.rb
+++ b/lib/elrte/router.rb
@@ -14,7 +14,7 @@ module Elrte
     #   end
     #
     def apply(router)
-      router.send(:get, {:elfinder => 'elfinder#connector', :as => 'elfinder_connector'})
+      router.send(:get, {'elfinder' => 'elfinder#connector', :as => 'elfinder_connector'})
     end
 
   end


### PR DESCRIPTION
Those are small additions to my previous PR. 
1. I replaced `:elfinder` with `'elfinder'` because it caused an error during installation, in `rails 4` app.

```
➜  myapp git:(admin_products) ✗ rails generate elrte:install
       route  Elrte.routes(self)
    generate  elrte:assets
/Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:229:in `default_controller_and_action': missing :controller (ArgumentError)
  from /Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:116:in `normalize_options!'
  from /Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:64:in `initialize'
................
  from /Users/vlad/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0.rc1/lib/action_dispatch/routing/mapper.rb:557:in `get'
  from /Users/vlad/Ruby/elrte-rails/lib/elrte/router.rb:17:in `apply'
  from /Users/vlad/Ruby/elrte-rails/lib/elrte/application.rb:11:in `routes'
  from /Users/vlad/Ruby/elrte-rails/lib/elrte.rb:23:in `routes'
  from /Users/vlad/Ruby/myapp/config/routes.rb:3:in `block in <top (required)>'
.......
```
1. Also I set it back to use `match`, but in `rails 4` way using `:via` to specify http methods explicitly. And added POST method for elfinder connector.
